### PR TITLE
Allow custom shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ folder (where you can tar them up and
 
 - `tail` - Max number of lines to show from each container.  Defaults to "all".
 
+- `shell` - Shell to execute commands.  Defaults to "/bin/bash".
+
 ## Usage
 
 ## Dump all logs on a failure
@@ -55,4 +57,14 @@ folder (where you can tar them up and
   with:
     name: logs.tgz
     path: ./logs.tgz
+```
+
+## Dump all logs on a failure using different shell
+
+```yaml
+- name: Dump docker logs on failure using different shell
+  if: failure()
+  uses: jwalton/gh-docker-logs@v1
+  with:
+    shell: '/bin/sh'
 ```

--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ const core = require('@actions/core');
 const dest = core.getInput('dest') || undefined;
 const images = core.getInput('images') || undefined;
 const tail = core.getInput('images') || 'all';
+const shell = core.getInput('shell') || '/bin/bash';
 
 const imagesFilter = typeof images === 'string' ? images.split(',') : undefined;
 
@@ -21,7 +22,7 @@ function run(cmd, options = {}) {
     }
 
     return execSync(cmd, {
-        shell: '/bin/bash',
+        shell,
         encoding: 'utf-8',
         env: process.env,
         stdio,


### PR DESCRIPTION
Hello!
I discovered your github action recently and it was exactly what I was looking for! However, I was using an Alpine container for my build and I needed to install `bash` in order for this to work. So, I propose an additional option to specify another shell to use.