### PR TITLE
fix(README): fix tarball upload example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ folder (where you can tar them up and
   if: failure()
   run: tar cvzf ./logs.tgz ./logs
 - name: Upload logs to GitHub
+  if: failure()
   uses: actions/upload-artifact@master
   with:
     name: logs.tgz


### PR DESCRIPTION
The example workflow would skip uploading the logs in case of failure.