### PR TITLE
Upgrade node version from 16 to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
     default: /bin/sh
 
 runs:
-  using: node16
+  using: node20
   main: 'dist/index.js'
 branding:
   icon: align-left


### PR DESCRIPTION
See these warnings that started popping up in our repos:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.